### PR TITLE
feat: add spawn method for deferred processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,36 @@ let output = PrivilegedCommand::new("/usr/bin/cat")
     .run()?;
 ```
 
+### Spawning without blocking
+
+Use `spawn()` to start a privileged process and continue working while it runs:
+
+```rust
+use privesc::PrivilegedCommand;
+
+fn main() -> privesc::Result<()> {
+    let mut child = PrivilegedCommand::new("/usr/bin/long-task")
+        .spawn()?;
+
+    if let Some(id) = child.id() {
+        println!("Process started with ID: {id}");
+    }
+
+    // Do other work while the process runs...
+
+    // Check if done without blocking
+    if let Some(status) = child.try_wait()? {
+        println!("Already finished: {status}");
+    }
+
+    // Block until completion
+    let output = child.wait()?;
+    println!("Exit status: {}", output.status);
+
+    Ok(())
+}
+```
+
 ## Platform Behavior
 
 | Platform | GUI mode | CLI mode | Output capture |

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -1,0 +1,29 @@
+use std::{thread::sleep, time::Duration};
+
+use privesc::PrivilegedCommand;
+
+fn main() {
+    // Spawn a privileged process without blocking
+    let mut child = PrivilegedCommand::new("sleep").arg("2").spawn().unwrap();
+
+    if let Some(id) = child.id() {
+        println!("Spawned process with ID: {id}");
+    }
+
+    // Do some work while the process runs
+    println!("Doing other work while process runs...");
+
+    sleep(Duration::from_secs(1));
+
+    // Check if the process has finished (non-blocking)
+    match child.try_wait().unwrap() {
+        Some(status) => println!("Process already finished with: {status}"),
+        None => println!("Process still running..."),
+    }
+
+    // Wait for the process to complete
+    println!("Waiting for process to finish...");
+    let output = child.wait().unwrap();
+
+    println!("Exit status: {}", output.status);
+}

--- a/src/privesc_darwin.rs
+++ b/src/privesc_darwin.rs
@@ -1,6 +1,6 @@
 use std::{
     io::Write,
-    process::{Command, Stdio},
+    process::{Child, Command, ExitStatus, Stdio},
 };
 
 use crate::PrivilegedOutput;
@@ -18,15 +18,52 @@ on run argv
 end run
 "#;
 
-/// Execute a program with elevated privileges using `osascript`.
+/// Platform-specific handle to a spawned privileged process.
+///
+/// This struct wraps the underlying process and provides methods to wait for
+/// completion and retrieve the output.
+pub struct PrivilegedChildInner {
+    child: Child,
+}
+
+impl PrivilegedChildInner {
+    /// Waits for the process to exit and returns the output.
+    ///
+    /// This method consumes the handle and blocks until the process
+    /// has finished executing.
+    pub fn wait(self) -> Result<PrivilegedOutput> {
+        let output = self.child.wait_with_output()?;
+        Ok(PrivilegedOutput {
+            status: output.status,
+            stdout: Some(output.stdout),
+            stderr: Some(output.stderr),
+        })
+    }
+
+    /// Attempts to collect the exit status of the child if it has already exited.
+    ///
+    /// This method will not block. Returns `Ok(None)` if the process has not
+    /// yet exited.
+    pub fn try_wait(&mut self) -> Result<Option<ExitStatus>> {
+        Ok(self.child.try_wait()?)
+    }
+
+    /// Returns the OS-assigned process identifier of the child process, if available.
+    pub fn id(&self) -> Option<u32> {
+        Some(self.child.id())
+    }
+}
+
+/// Spawn a program with elevated privileges using `osascript`.
 ///
 /// # Args:
 /// - `program` - The path to the program to execute.
 /// - `args` - The arguments to pass to the program.
+/// - `prompt` - The prompt to display to the user.
 ///
 /// # Returns:
-/// - `Result<PrivilegedOutput>` - The output of the program.
-fn privesc_gui(program: &str, args: &[&str], prompt: Option<&str>) -> Result<PrivilegedOutput> {
+/// - `Result<PrivilegedChildInner>` - A handle to the spawned process.
+fn spawn_gui(program: &str, args: &[&str], prompt: Option<&str>) -> Result<PrivilegedChildInner> {
     let mut process = Command::new("osascript")
         .arg("-")
         .arg(program)
@@ -45,15 +82,10 @@ fn privesc_gui(program: &str, args: &[&str], prompt: Option<&str>) -> Result<Pri
         .expect("stdin piped")
         .write_all(ESCALLATION_SCRIPT.as_bytes())?;
 
-    let output = process.wait_with_output()?;
-    Ok(PrivilegedOutput {
-        status: output.status,
-        stdout: Some(output.stdout),
-        stderr: Some(output.stderr),
-    })
+    Ok(PrivilegedChildInner { child: process })
 }
 
-/// Execute a program with elevated privileges using `sudo`.
+/// Spawn a program with elevated privileges using `sudo`.
 ///
 /// # Args:
 /// - `program` - The path to the program to execute.
@@ -61,8 +93,8 @@ fn privesc_gui(program: &str, args: &[&str], prompt: Option<&str>) -> Result<Pri
 /// - `prompt` - The prompt to display to the user.
 ///
 /// # Returns:
-/// - `Result<PrivilegedOutput>` - The output of the program.
-fn privesc_cli(program: &str, args: &[&str], prompt: Option<&str>) -> Result<PrivilegedOutput> {
+/// - `Result<PrivilegedChildInner>` - A handle to the spawned process.
+fn spawn_cli(program: &str, args: &[&str], prompt: Option<&str>) -> Result<PrivilegedChildInner> {
     let mut command = Command::new("sudo");
 
     if let Some(prompt) = prompt {
@@ -78,12 +110,30 @@ fn privesc_cli(program: &str, args: &[&str], prompt: Option<&str>) -> Result<Pri
         .stderr(Stdio::piped())
         .spawn()?;
 
-    let output = process.wait_with_output()?;
-    Ok(PrivilegedOutput {
-        status: output.status,
-        stdout: Some(output.stdout),
-        stderr: Some(output.stderr),
-    })
+    Ok(PrivilegedChildInner { child: process })
+}
+
+/// Spawn a program with elevated privileges using either `osascript` or `sudo`.
+///
+/// # Args:
+/// - `program` - The path to the program to execute.
+/// - `args` - The arguments to pass to the program.
+/// - `gui` - Whether to prompt the user for a password using GUI or sudo.
+/// - `prompt` - The prompt to display to the user.
+///
+/// # Returns:
+/// - `Result<PrivilegedChildInner>` - A handle to the spawned process.
+pub fn spawn(
+    program: &str,
+    args: &[&str],
+    gui: bool,
+    prompt: Option<&str>,
+) -> Result<PrivilegedChildInner> {
+    if gui {
+        spawn_gui(program, args, prompt)
+    } else {
+        spawn_cli(program, args, prompt)
+    }
 }
 
 /// Execute a program with elevated privileges using either `osascript` or `sudo`.
@@ -96,15 +146,11 @@ fn privesc_cli(program: &str, args: &[&str], prompt: Option<&str>) -> Result<Pri
 ///
 /// # Returns:
 /// - `Result<PrivilegedOutput>` - The output of the program.
-pub fn privesc(
+pub fn run(
     program: &str,
     args: &[&str],
     gui: bool,
     prompt: Option<&str>,
 ) -> Result<PrivilegedOutput> {
-    if gui {
-        privesc_gui(program, args, prompt)
-    } else {
-        privesc_cli(program, args, prompt)
-    }
+    spawn(program, args, gui, prompt)?.wait()
 }

--- a/src/privesc_linux.rs
+++ b/src/privesc_linux.rs
@@ -1,16 +1,52 @@
 use crate::PrivilegedOutput;
 use crate::error::{PrivescError, Result};
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, ExitStatus, Stdio};
 
-/// Execute a program with elevated privileges using `pkexec`.
+/// Platform-specific handle to a spawned privileged process.
+///
+/// This struct wraps the underlying process and provides methods to wait for
+/// completion and retrieve the output.
+pub struct PrivilegedChildInner {
+    child: Child,
+}
+
+impl PrivilegedChildInner {
+    /// Waits for the process to exit and returns the output.
+    ///
+    /// This method consumes the handle and blocks until the process
+    /// has finished executing.
+    pub fn wait(self) -> Result<PrivilegedOutput> {
+        let output = self.child.wait_with_output()?;
+        Ok(PrivilegedOutput {
+            status: output.status,
+            stdout: Some(output.stdout),
+            stderr: Some(output.stderr),
+        })
+    }
+
+    /// Attempts to collect the exit status of the child if it has already exited.
+    ///
+    /// This method will not block. Returns `Ok(None)` if the process has not
+    /// yet exited.
+    pub fn try_wait(&mut self) -> Result<Option<ExitStatus>> {
+        Ok(self.child.try_wait()?)
+    }
+
+    /// Returns the OS-assigned process identifier of the child process, if available.
+    pub fn id(&self) -> Option<u32> {
+        Some(self.child.id())
+    }
+}
+
+/// Spawn a program with elevated privileges using `pkexec`.
 ///
 /// # Args:
 /// - `program` - The path to the program to execute.
 /// - `args` - The arguments to pass to the program.
 ///
 /// # Returns:
-/// - `Result<PrivilegedOutput>` - The output of the program.
-fn privesc_gui(program: &str, args: &[&str]) -> Result<PrivilegedOutput> {
+/// - `Result<PrivilegedChildInner>` - A handle to the spawned process.
+fn spawn_gui(program: &str, args: &[&str]) -> Result<PrivilegedChildInner> {
     if which::which("pkexec").is_err() {
         return Err(PrivescError::PrivilegeEscalationToolNotFound(
             "pkexec".to_string(),
@@ -25,15 +61,10 @@ fn privesc_gui(program: &str, args: &[&str]) -> Result<PrivilegedOutput> {
         .stderr(Stdio::piped())
         .spawn()?;
 
-    let output = process.wait_with_output()?;
-    Ok(PrivilegedOutput {
-        status: output.status,
-        stdout: Some(output.stdout),
-        stderr: Some(output.stderr),
-    })
+    Ok(PrivilegedChildInner { child: process })
 }
 
-/// Execute a program with elevated privileges using `sudo`.
+/// Spawn a program with elevated privileges using `sudo`.
 ///
 /// # Args:
 /// - `program` - The path to the program to execute.
@@ -41,8 +72,8 @@ fn privesc_gui(program: &str, args: &[&str]) -> Result<PrivilegedOutput> {
 /// - `prompt` - The prompt to display to the user.
 ///
 /// # Returns:
-/// - `Result<PrivilegedOutput>` - The output of the program.
-fn privesc_cli(program: &str, args: &[&str], prompt: Option<&str>) -> Result<PrivilegedOutput> {
+/// - `Result<PrivilegedChildInner>` - A handle to the spawned process.
+fn spawn_cli(program: &str, args: &[&str], prompt: Option<&str>) -> Result<PrivilegedChildInner> {
     let mut command = Command::new("sudo");
 
     if let Some(prompt) = prompt {
@@ -58,12 +89,30 @@ fn privesc_cli(program: &str, args: &[&str], prompt: Option<&str>) -> Result<Pri
         .stderr(Stdio::piped())
         .spawn()?;
 
-    let output = process.wait_with_output()?;
-    Ok(PrivilegedOutput {
-        status: output.status,
-        stdout: Some(output.stdout),
-        stderr: Some(output.stderr),
-    })
+    Ok(PrivilegedChildInner { child: process })
+}
+
+/// Spawn a program with elevated privileges using either `pkexec` or `sudo`.
+///
+/// # Args:
+/// - `program` - The path to the program to execute.
+/// - `args` - The arguments to pass to the program.
+/// - `gui` - Whether to prompt the user for a password using GUI or sudo.
+/// - `prompt` - The prompt to display to the user. Only used if `gui` is false due to `pkexec` limitations.
+///
+/// # Returns:
+/// - `Result<PrivilegedChildInner>` - A handle to the spawned process.
+pub fn spawn(
+    program: &str,
+    args: &[&str],
+    gui: bool,
+    prompt: Option<&str>,
+) -> Result<PrivilegedChildInner> {
+    if gui {
+        spawn_gui(program, args)
+    } else {
+        spawn_cli(program, args, prompt)
+    }
 }
 
 /// Execute a program with elevated privileges using either `pkexec` or `sudo`.
@@ -76,15 +125,11 @@ fn privesc_cli(program: &str, args: &[&str], prompt: Option<&str>) -> Result<Pri
 ///
 /// # Returns:
 /// - `Result<PrivilegedOutput>` - The output of the program.
-pub fn privesc(
+pub fn run(
     program: &str,
     args: &[&str],
     gui: bool,
     prompt: Option<&str>,
 ) -> Result<PrivilegedOutput> {
-    if gui {
-        privesc_gui(program, args)
-    } else {
-        privesc_cli(program, args, prompt)
-    }
+    spawn(program, args, gui, prompt)?.wait()
 }


### PR DESCRIPTION
This PR adds a `spawn` method that lanches the process but does not wait for it to finish, while also exposing methods that allow awaiting its output.