### PR TITLE
fix: take stdin on macOS so that EOF is sent to AppleScript

### DIFF
--- a/src/privesc_darwin.rs
+++ b/src/privesc_darwin.rs
@@ -78,7 +78,7 @@ fn spawn_gui(program: &str, args: &[&str], prompt: Option<&str>) -> Result<Privi
 
     process
         .stdin
-        .as_mut()
+        .take()
         .expect("stdin piped")
         .write_all(ESCALLATION_SCRIPT.as_bytes())?;
 


### PR DESCRIPTION
This PR fixes a bug in which the AppleScript `stdin` was not closed (EOF was not sent), hence not spawning the authorization/prompt process at all.